### PR TITLE
webコンテナ追加

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,4 +33,8 @@ services:
         published: ${WEB_PORT:-80}
         protocol: tcp
         mode: host
-        
+    volumes:
+      - type: bind
+        source: ./backend
+        target: /work/backend
+  


### PR DESCRIPTION
## webサーバーコンテナの作成

### やったこと
・webサーバーコンテナを定義：php以外の静的コンテンツを返すやつ（app serverでphpを実行）
・nginxのポートを設定：80

