### PR TITLE
phpのdockerfileを追加

### DIFF
--- a/infra/docker/php/Dockerfile
+++ b/infra/docker/php/Dockerfile
@@ -1,0 +1,31 @@
+FROM php:7.4-fpm-buster
+LABEL maintainer="soregashi27"
+SHELL ["/bin/bash", "-ouex", "pipefail", "-c"]
+
+# timezone environment
+ENV TZ=UTC \
+  # locale
+  LANG=en_US.UTF-8 \
+  LANGUAGE=en_US:en \
+  LC_ALL=en_US.UTF-8 \
+  # composer environment
+  COMPOSER_ALLOW_SUPERUSER=1 \
+  COMPOSER_HOME=/composer
+
+COPY --from=composer:2.0 /usr/bin/composer /usr/bin/composer
+
+RUN apt-get update && \
+  apt-get -y install git libicu-dev libonig-dev libzip-dev unzip locales && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/* && \
+  locale-gen en_US.UTF-8 && \
+  localedef -f UTF-8 -i en_US en_US.UTF-8 && \
+  mkdir /var/run/php-fpm && \
+  docker-php-ext-install intl pdo_mysql zip bcmath && \
+  composer config -g process-timeout 3600 && \
+  composer config -g repos.packagist composer https://packagist.org
+
+COPY ./infra/docker/php/php-fpm.d/zzz-www.conf /usr/local/etc/php-fpm.d/zzz-www.conf
+COPY ./infra/docker/php/php.ini /usr/local/etc/php/php.ini
+
+WORKDIR /work/backend


### PR DESCRIPTION
# phpのDockerfileを追加

## やったこと
### FROM命令
・php7.4のImageを指定
・fpm→phpを実行するapp serverのみ
・コンテナOSはbuster→alpineはlaravel入門者にはオススメできないらしいのでこれを選択。

### SHELL命令
・これを参照 https://bit.ly/3AE4MJl
この設定がいいらしいので一旦これにした

### ENV命令
・タイムゾーン、言語設定

### COPY命令
・Composerの設定（2.*を使用）

### RUN命令
・コマンドを実行した結果をコミット

### COPY命令
・ファイル、またはDirをコンテナのパスにコピー

ワンライナーで実行できるところはワンライナーにしてImage layer数を減らす
