### PR TITLE
php-fpmの設定を追加【Deploy時は再度確認】

### DIFF
--- a/infra/docker/php/php-fpm.d/zzz-www.conf
+++ b/infra/docker/php/php-fpm.d/zzz-www.conf
@@ -1,0 +1,6 @@
+[www]
+listen = /var/run/php-fpm/php-fpm.sock
+listen.owner = www-data
+listen.group = www-data
+listen.mode = 0666
+access.log = /dev/stdout

--- a/infra/docker/php/php.ini
+++ b/infra/docker/php/php.ini
@@ -1,0 +1,25 @@
+zend.exception_ignore_args = off
+expose_php = on
+max_execution_time = 30
+max_input_vars = 1000
+upload_max_filesize = 64M
+post_max_size = 128M
+memory_limit = 256M
+error_reporting = E_ALL
+display_errors = on
+display_startup_errors = on
+log_errors = on
+error_log = /dev/stderr
+default_charset = UTF-8
+
+[Date]
+date.timezone = ${TZ}
+
+[mysqlnd]
+mysqlnd.collect_memory_statistics = on
+
+[Assertion]
+zend.assertions = 1
+
+[mbstring]
+mbstring.language = Neutral


### PR DESCRIPTION
### ./docker/php/php-fpm.d/zzz-www.conf
・nginxとphp-fpm間の通信はTCP、またはUNIX domain socketで通信を行う
socket通信：TCP/IP（Internetで利用されてる通信方法）をプログラムから利用するための窓口（Socket）を使って通信すること

参考：PHPの公式DockerイメージでUNIXソケット通信しようとして罠にハマるの巻
https://bit.ly/3jWBgHU

###  php.ini
こちらを参照
https://bit.ly/3jNjFly
※デプロイ時に設定を変更する

下記に書き換える

```
zend.exception_ignore_args = on
expose_php = off
max_execution_time = 30
max_input_vars = 1000
upload_max_filesize = 64M
post_max_size = 128M
memory_limit = 256M
error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
display_errors = off
display_startup_errors = off
log_errors = on
error_log = /var/log/php/php-error.log
default_charset = UTF-8

[Date]
date.timezone = Asia/Tokyo

[mysqlnd]
mysqlnd.collect_memory_statistics = off

[Assertion]
zend.assertions = -1

[mbstring]
mbstring.language = Japanese

[opcache]
opcache.enable = 1
opcache.memory_consumption = 128
opcache.interned_strings_buffer = 8
opcache.max_accelerated_files = 4000
opcache.validate_timestamps = 0
opcache.huge_code_pages = 0
opcache.preload = /var/www/preload.php
opcache.preload_user = www-data
```

