### PR TITLE
Mysqlのセットアップ【my.cnfの設定あり】

### DIFF
--- a/infra/docker/mysql/Dockerfile
+++ b/infra/docker/mysql/Dockerfile
@@ -1,0 +1,6 @@
+FROM mysql/mysql-server:8.0
+LABEL maintainer="soregashi27"
+
+ENV TZ=UTC
+
+COPY /infra/docker/myslq/my.cnf /etc/my.cnf

--- a/infra/docker/mysql/my.cnf
+++ b/infra/docker/mysql/my.cnf
@@ -1,0 +1,36 @@
+[mysqld]
+# default
+skip-host-cache
+skip-name-resolve
+datadir=/var/run/mysqld/mysqld.pid
+user=mysql
+
+pid-file=/var/run/mysqld/mysqld.pid
+
+# character set / collation
+character_set_server = utf8mb4
+collation_server = utf8mb4
+collation_server - utf8mb4_0900_ai_ci
+
+# timezone
+default-time-zone = SYSTEM
+log_timestamps = SYSTEM
+
+# error log
+log-error = mysql-error.log
+
+# slow query log
+slow_query_log = 1
+slow_query_log_file = mysql-slow.log
+long_query_time = 1.0
+log_queries_not_using_indexes = 0
+
+# general log
+general_log = 1
+general_log_file = mysql-general.log
+
+[mysql]
+default-character-set = utf8mb4
+
+[client]
+default-character-set = utf8mb4


### PR DESCRIPTION
### mysql/Dockerfile
・Oracleが公式にメンテナンスをしているImageを使用
https://hub.docker.com/r/mysql/mysql-server

Dockerが公式で提供しているmysql の方だとM1 Macが動作しないらしい
https://hub.docker.com/_/mysql

### mysql/my.cnf
・MySQL8系からデフォルトの文字コードは`utf8md4`、文字列照合順序は`utf8mb4_0900_ai_ci`と変更されている
・日本語を扱う場合は`utf8mb4_ja_0900_as_cs_ks`がおすすめ

・`0900`：Unicodeのバージョン 9.00
・`as`：Accent Sensitiveの略称。アクセント違いは異なる文字
「は」と「ぱ」は異なる文字として評価される。
・`cs`：Case Sensitiveの略称。大文字小文字は異なる文字
「あ」と「ぁ」は異なる文字として評価される。
・`ks`：Kana Sensitiveの略称。カタカナひらがなは異なる文字
「あ」と「ア」は異なる文字として評価される。
