### PR TITLE
DBコンテナの接続を確認

### DIFF
--- a/infra/docker/mysql/my.cnf
+++ b/infra/docker/mysql/my.cnf
@@ -2,15 +2,16 @@
 # default
 skip-host-cache
 skip-name-resolve
-datadir=/var/run/mysqld/mysqld.pid
-user=mysql
+datadir = /var/lib/mysql
+socket = /var/lib/mysql/mysql.sock
+secure-file-priv = /var/lib/mysql-files
+user = mysql
 
 pid-file=/var/run/mysqld/mysqld.pid
 
 # character set / collation
 character_set_server = utf8mb4
-collation_server = utf8mb4
-collation_server - utf8mb4_0900_ai_ci
+collation_server = utf8mb4_0900_ai_ci
 
 # timezone
 default-time-zone = SYSTEM


### PR DESCRIPTION
MySQLのバージョン確認
```
[mac] docker compose exec db mysql -V
>mysql  Ver 8.0.26 for Linux on x86_64 (MySQL Community Server - GPL)
```

MySQLのData dirの設定
```
datadir = /var/lib/mysql
```

ソケット通信の設定
```
socket = /var/lib/mysql/mysql.sock
```

ファイル作成権限の設定
```
secure-file-priv = /var/lib/mysql-files
```