### PR TITLE
phpmyadminとlaravelの接続を確認

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,19 @@ volumes:
   php-fpm-socket:
   db-store:
   psysh-store:
+  pma-session-store:
 services:
+  pma:
+    image: phpmyadmin/phpmyadmin
+    environment:
+      - PMA_HOST=db
+      - PMA_USER=soregashi27
+      - PMA_PASSWORD=soregashidegozaru
+    ports:
+      - 8080:80
+    volumes:
+      - pma-session-store:/sessions
+
   app:
     build:
       context: .
@@ -22,13 +34,13 @@ services:
         target: /root/.config/psysh
         volume:
           nocopy: true
-    # environment:
-    #   - DB_CONNECTION=mysql
-    #   - DB_HOST=db
-    #   - DB_PORT=3306
-    #   - DB_DATABASE=${DB_NAME:-laravel_local}
-    #   - DB_USERNAME=${DB_USER:-soregashi27}
-    #   - DB_PASSWORD=${DB_PASS:-soregashidegozaru}
+    environment:
+      - DB_CONNECTION=mysql
+      - DB_HOST=db
+      - DB_PORT=3306
+      - DB_DATABASE=${DB_NAME:-laravel_local}
+      - DB_USERNAME=${DB_USER:-soregashi27}
+      - DB_PASSWORD=${DB_PASS:-soregashidegozaru}
 
   web:
     build:
@@ -36,7 +48,7 @@ services:
       dockerfile: ./infra/docker/nginx/Dockerfile
     ports:
       - target: 80
-        published: 8080
+        published: ${WEB_PORT:-80}
         protocol: tcp
         mode: host
     volumes:
@@ -55,8 +67,8 @@ services:
       dockerfile: ./infra/docker/mysql/Dockerfile
     ports:
       - target: 3306
-        # published: ${DB_PORT:-3306}
-        published: 3306
+        published: ${DB_PORT:-3306}
+        # published: 3306
         protocol: tcp
         mode: host
     volumes:
@@ -65,8 +77,8 @@ services:
         target: /var/lib/mysql
         volume:
           nocopy: true
-    # environment:
-    #   - MYSQL_DATABASE=${DB_NAME:-laravel_local}
-    #   - MYSQL_USER=${DB_USER:-soregashi27}
-    #   - MYSQL_PASSWORD=${DB_PASS:-soregashidegozaru}
-    #   - MYSQL_ROOT_PASSWORD=${DB_PASS:-soregashidegozaru}
+    environment:
+      - MYSQL_DATABASE=${DB_NAME:-laravel_local}
+      - MYSQL_USER=${DB_USER:-soregashi27}
+      - MYSQL_PASSWORD=${DB_PASS:-soregashidegozaru}
+      - MYSQL_ROOT_PASSWORD=${DB_PASS:-soregashidegozaru}


### PR DESCRIPTION

### ポートの設定
ポートが80番の場合は省略できるので下記のURLに接続できればOK

```
http://127.0.0.1/
```

これは`http://127.0.0.1:80`と同じ
80 番以外のポート番号を使う場合は、Webサーバにアクセスする時にポート番号を付与してアクセスする必要がある。



### 環境変数の設定
環境変数とは**OS上で動作するタスク（プロセス）がデータを共有するための仕組み**

今回の場合は`.env`ファイルで宣言しているものと対応させている

※あらかじめ`.env.example`を書いておくやり方もあるが、laravel内で生成される`.env`ファイルと対応させるやり方に慣れてるのでこっちを採用


-----------

laravelがちゃんと立ち上がるかテスト

※`--build`コマンドを使う場合は`--`2つつかうこと！

```
[mac] $ docker compose up -d --build
```



`docker compose` コマンドは `docker-compose.yml` があるディレクトリで実行。

`docker compose up` で `docker-compose.yml` に定義したサービスを起動できる。

```
-d
```

「デタッチド」モードでのコンテナ起動。

デフォルトは「アタッチド」モードで全てのコンテナログを画面上に表示するが、この場合だとDocker shell内に入るために新たなTerminal画面を開く必要がある。

「デタッチド」モードではバックグラウンドで動作できるので、そのままDocker shell内に入って操作をすることができる。

```
--build
```

 コンテナの開始前にイメージを構築。
特に変更がない場合はキャッシュが使用される。



Docker環境をキレイにしたい場合はこれ
**docker file, imageの滅びの呪文**

```
docker compose down --rmi all --volumes --remove-orphans
```

参考：《滅びの呪文》Docker Composeで作ったコンテナ、イメージ、ボリューム、ネットワークを一括完全消去する便利コマンド
https://bit.ly/3AXhmn8